### PR TITLE
 Adds the Chocolatey package as a way to install the Google Meet Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@
 
 You can [download the latest release](https://github.com/arjun-g/google-meet-desktop/releases) for your operating system or build it yourself (see below).
 
+On Windows, you can also use the [Chocolatey package](https://community.chocolatey.org/packages/unofficial-google-meet), in order to do the installation/update:
+```powershell
+choco install unofficial-google-meet
+```
+
 ## Building
 
 You'll need [Node.js](https://nodejs.org) installed on your computer in order to build this app.


### PR DESCRIPTION
Hi @google-meet-desktop_devs,

I have created this Pull Request because I have resolved this [request for a Chocolatey package](https://github.com/chocolatey-community/chocolatey-package-requests/issues/1311) and now, we can install **unofficial-google-meet** using [Chocolatey](https://community.chocolatey.org/packages/unofficial-google-meet).

For now, only the latest version (`1.20.0`) is available on Chocolatey. When new versions will be released, they will, then, be added to the Chocolatey package for users to enjoy. :slightly_smiling_face: 

